### PR TITLE
Need to add AR to configure after cherry-picking from upstream.

### DIFF
--- a/configure
+++ b/configure
@@ -655,6 +655,7 @@ LDFLAGS
 CFLAGS
 CC
 RANLIB
+AR
 target_alias
 host_alias
 build_alias


### PR DESCRIPTION
Otherwise the `configure` script won't retrieve the `AR` environment var.
